### PR TITLE
add customisable variable to control source buffer locking

### DIFF
--- a/realgud/common/custom.el
+++ b/realgud/common/custom.el
@@ -6,4 +6,10 @@
   :type 'string
   :group 'realgud)
 
+(defcustom realgud-srcbuf-lock t
+  "Set source buffers read-only when the debugger is active.
+A setting of `nil` allows editing, but Short-Key-mode use may inhibit this."
+  :type 'boolean
+  :group 'realgud)
+
 (provide-me "realgud-")

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -71,7 +71,7 @@ MODE-ON? a boolean which specifies if we are going into or out of this mode."
                 (progn
                   (realgud-srcbuf-info-was-read-only?= buffer-read-only)
                   (local-set-key [M-insert] 'realgud-short-key-mode)
-                  (setq buffer-read-only t)
+                  (when realgud-srcbuf-lock (setq buffer-read-only t))
                   (run-mode-hooks 'realgud-short-key-mode-hook))
                 ;; Mode is being turned off: restore read-only state.
                 (setq buffer-read-only


### PR DESCRIPTION
this should really just be the single commit, 'add customisable variable to control source buffer locking' but was based on 'https://github.com/rocky/emacs-dbgr/pull/23' (the other two commits) so to avoid giving you merge conflicts given the code overlaps

the reason behind the three commits was the feeling i had of needing to 'regain control of the debugging process / buffers'. the default setup felt restrictive. i like editing on the fly (and thus restarting the process as and when the edits require it), and i like scrolling around the source buffer

the default short-key mode map also overrode many of my customisations, and try as i might, i failed to change to the map in any of the standard emacsy ways i knew, possibly due to the mix of populating the map on the fly, and the setup calls being initiated from the debugger process' buffer

this could all be unnecessary and i may have missed an intended trick, however, supporting standard emacs features like hooks is certainly preferable for me, so hence the hope of a merge

thanks for all your work on the project
