### PR TITLE
add customisable variable to control source buffer locking

### DIFF
--- a/realgud/common/custom.el
+++ b/realgud/common/custom.el
@@ -6,4 +6,10 @@
   :type 'string
   :group 'realgud)
 
+(defcustom realgud-srcbuf-lock t
+  "Set source buffers read-only when the debugger is active.
+A setting of `nil` allows editing, but Short-Key-mode use may inhibit this."
+  :type 'boolean
+  :group 'realgud)
+
 (provide-me "realgud-")

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -71,7 +71,7 @@ MODE-ON? a boolean which specifies if we are going into or out of this mode."
                 (progn
                   (realgud-srcbuf-info-was-read-only?= buffer-read-only)
                   (local-set-key [M-insert] 'realgud-short-key-mode)
-                  (setq buffer-read-only t)
+                  (when realgud-srcbuf-lock (setq buffer-read-only t))
                   (run-mode-hooks 'realgud-short-key-mode-hook))
                 ;; Mode is being turned off: restore read-only state.
                 (setq buffer-read-only


### PR DESCRIPTION
-allow users to control whether the source buffers associated with
the debugger process(es) are locked (read-only mode enabled) when
debugging is in progress
