### PR TITLE
Further cleanups of cmds.el + improved C-u behaviour

### DIFF
--- a/realgud/common/cmds.el
+++ b/realgud/common/cmds.el
@@ -128,7 +128,7 @@ as in `realgud:cmd-run-command'."
 (make-obsolete 'realgud:cmd-remap 'realgud:cmd-run-command "1.3.1")
 
 (defun realgud:cmd-backtrace(arg)
-  "Show the current call stack"
+  "Show the current call stack."
   (interactive "p")
   (realgud:cmd-run-command arg "backtrace")
   )
@@ -254,11 +254,10 @@ If no argument specified use 0 or the most recent frame."
     (realgud:cmd-run-command arg "frame" nil t t)
 )
 
-(defun realgud:cmd-kill(arg)
-  "kill debugger process"
-  (interactive "p")
-  (realgud:cmd-run-command arg "kill" nil nil nil t)
-  )
+(defun realgud:cmd-kill()
+  "Kill debugger process."
+  (interactive)
+  (realgud:cmd-run-command nil "kill" nil nil nil t))
 
 (defun realgud:cmd-newer-frame(&optional arg)
     "Move the current frame to a newer (more recent) frame.
@@ -280,8 +279,8 @@ what is getting stepped."
     (interactive "p")
     (realgud:cmd-run-command count "next"))
 
-(defun realgud:cmd-next-no-arg(&optional arg)
-    "Step one source line at current call level.
+(defun realgud:cmd-next-no-arg()
+  "Step one source line at current call level.
 
 The definition of 'next' is debugger specific so, see the
 debugger documentation for a more complete definition of what is
@@ -296,23 +295,20 @@ With a numeric argument move that many levels back."
     (realgud:cmd-run-command arg "up" nil t t)
 )
 
-(defun realgud:cmd-repeat-last(&optional arg)
-    "Repeat the last command (or generally what <enter> does."
-    (interactive "")
-    (realgud:cmd-run-command arg "repeat-last" nil t nil t)
-)
+(defun realgud:cmd-repeat-last()
+  "Repeat the last command (or generally what <enter> does."
+  (interactive)
+  (realgud:cmd-run-command nil "repeat-last" nil t nil t))
 
-(defun realgud:cmd-restart(&optional arg)
-    "Restart execution."
-    (interactive "")
-    (realgud:cmd-run-command arg "restart" nil t nil t)
-)
+(defun realgud:cmd-restart()
+  "Restart execution."
+  (interactive)
+  (realgud:cmd-run-command nil "restart" nil t nil t))
 
-(defun realgud:cmd-shell(&optional arg)
-    "Drop to a shell."
-    (interactive "")
-    (realgud:cmd-run-command arg "shell")
-)
+(defun realgud:cmd-shell()
+  "Drop to a shell."
+  (interactive)
+  (realgud:cmd-run-command nil "shell"))
 
 (defun realgud:cmd-step(&optional count)
     "Step one source line.
@@ -372,10 +368,10 @@ continuing execution."
 	    (unless (and cmd-hash (setq cmd (gethash "quit" cmd-hash)))
 	      (setq cmd "quit"))
 	    )
-	  (realgud-command cmd arg 't)
+          (realgud-command cmd arg t)
 	  (if cmdbuf (realgud:terminate cmdbuf))
 	  )
-      ; else
+      ;; else
       (realgud:terminate-srcbuf buffer)
       )
     )

--- a/realgud/common/send.el
+++ b/realgud/common/send.el
@@ -116,6 +116,13 @@ results into the command buffer."
 (defun realgud-send-command-invisible (command-str)
   (realgud-send-command command-str (function realgud-send-command-process)))
 
+(defvar realgud-expand-format-overrides nil
+  "An alist of overrides for `realgud-expand-format'.
+Each element should have the form (KEY . VALUE).  Key should be a
+single-character escape accepted by `realgud-expand-format';
+value should be a string.  Every time %KEY is encountered in te
+string, it will be replaced by VALUE instead of being processed
+as usual.  If VALUE is nil, the override is ignored.")
 
 (defun realgud-expand-format (fmt-str &optional opt-str opt-buffer)
   "Expands commands format characters inside FMT-STR.
@@ -148,6 +155,7 @@ taken from current buffer, or OPT-BUFFER if non-nil.  Some
 	      (concat
 	       result (match-string 1 fmt-str)
 	       (cond
+		((cdr (assq key realgud-expand-format-overrides)))
 		((eq key ?d)
 		 (or (and src-file-name
 			  (file-name-directory src-file-name))


### PR DESCRIPTION
This gives `break` and `clear` a more interesting C-u interface, which prompts for a line number with plain C-u and uses the given number with C-number.

I had to make a small extension to format-command, to allow overriding flags: this seems much better than changing all of break commands in all debuggers to use `%p` instead of `%l`. What now happens is that the call to `run-cmd` gets wrapped in a let-binding that overrides the meaning of `%l` for the duration of that call.

I took that opportunity to clean up commands which took optional arguments but did not use them.