### PR TITLE
Don't bind standard keys when disabled by config

### DIFF
--- a/realgud/common/key.el
+++ b/realgud/common/key.el
@@ -92,9 +92,7 @@ source-code buffers
 The variable `realgud-populate-common-fn-keys-function' controls the layout."
   (define-key map "\C-x\C-a\C-q" 'realgud-short-key-mode)
   (if realgud-populate-common-fn-keys-function
-      (funcall realgud-populate-common-fn-keys-function map))
-  (realgud-populate-common-fn-keys-standard map)
-)
+      (funcall realgud-populate-common-fn-keys-function map)))
 
 (defun realgud-populate-src-buffer-map-plain (map)
   "Bind ordinary text characters used in debugger source-code buffers.


### PR DESCRIPTION
The realgud-populate-common-fn-keys-standard map function was always
run, even when realgud-populate-common-fn-keys-function was configured
as nil. Fixes #129