### PR TITLE
allow ansi color codes in ipdb prompt regexp

### DIFF
--- a/realgud/debugger/ipdb/init.el
+++ b/realgud/debugger/ipdb/init.el
@@ -49,9 +49,18 @@ realgud-loc-pat struct")
        :file-group 1
        :line-group 2))
 
+;; Regular expression that describes an ipdb prompt
+;;
+;; The comint-redirect-* commands (used e.g. for completion in the
+;; ipdb shell) do not allow applying filters when checking for the
+;; prompt signifying an end of the process output. Therefore we need
+;; to construct the regexp allowing for ansi color control sequences.
 (setf (gethash "prompt" realgud:ipdb-pat-hash)
       (make-realgud-loc-pat
-       :regexp   "^ipdb[>] "
+       :regexp (concat
+		"^\\(" ansi-color-regexp "\\)?"
+		"ipdb[>] "
+		"\\(" ansi-color-regexp "\\)?")
        ))
 
 ;;  Regular expression that describes a Python backtrace line.


### PR DESCRIPTION
comint-redirect-\* commands used for getting completion candidates do not
allow running a filter before testing for the prompt in the ipdb
output. If we cannot filter we must allow for ansi color codes to be
present in the prompt regexp.

This problem actually led to the emacs blocking because it was caught in an eternal loop in the `realgud:ipdb-backend-complete` function because the `comint-redirect-completed` would never be set due to the prompt not matching. In the head of the repo which I had checked out just this morning emacs got no longer stuck (so some fixing had been done), but still there is some garbage leftover from the control sequences around, so I still propose this fix.

Being able to put a filter before the test for the prompt matching occurs might also be nice, but would require fiddling with the already complex comint code, and introduce yet another filter hook.
