### PR TITLE
Fix infinite loop in realgud:backtrace-init

### DIFF
--- a/realgud/common/buffer/backtrace.el
+++ b/realgud/common/buffer/backtrace.el
@@ -407,6 +407,8 @@ filename, line number, whether the frame is selected as text properties."
 	    ;; FIXME: Remove hack that group 1 is always the frame indicator.
 	    (frame-indicator
 	     (substring stripped-string (match-beginning 1) (match-end 1)))
+	    (whole-match-begin (match-beginning 0))
+	    (whole-match-end (match-end 0))
 	    (frame-num-pos)
 
 	    )
@@ -462,12 +464,12 @@ filename, line number, whether the frame is selected as text properties."
 
 	(when (and (stringp filename) (numberp line-num))
 	  (let ((loc (realgud:file-loc-from-line filename line-num cmdbuf)))
-	    (put-text-property (match-beginning 0) (match-end 0)
+	    (put-text-property whole-match-begin whole-match-end
 			       'loc loc string)
 	    ))
-	(put-text-property (match-beginning 0) (match-end 0)
+	(put-text-property whole-match-begin whole-match-end
 			   'frame-num  frame-num string)
-	(setq last-pos (match-end 0))
+	(setq last-pos whole-match-end)
 
 	(if (string-match frame-indicator-re frame-indicator)
 	  (setq selected-frame-num frame-num))

--- a/test/test-bt-trepan2.el
+++ b/test/test-bt-trepan2.el
@@ -4,15 +4,19 @@
 (require 'test-simple)
 (require 'load-relative)
 (load-file "./bt-helper.el")
+(load-file "./regexp-helper.el")
 (load-file "../realgud/debugger/trepan2/init.el")
 
 (declare-function setup-bt 'realgud-bt-helper)
+(declare-function setup-regexp-vars 'regexp-helper)
 (declare-function __FILE__ 'load-relative)
 
 (test-simple-start)
 
 (eval-when-compile
   (defvar temp-bt)
+  (defvar realgud-pat-bt)
+  (defvar realgud:trepan2-pat-hash)
 )
 
 (setq temp-bt
@@ -40,4 +44,34 @@
 		  (get-text-property (point) 'face))
     )
   )
+
+
+(setup-regexp-vars realgud:trepan2-pat-hash)
+(setq realgud-pat-bt  (gethash "debugger-backtrace"
+                               realgud:trepan2-pat-hash))
+
+
+(let* ((triple
+        (realgud:backtrace-add-text-properties
+         realgud-pat-bt ""
+         "->0 gcd(a=3, b=5) called from file '/test/gcd.py' at line 28
+##1 <module> exec() '/test/gcd.py' at line 41"
+         "->"))
+       (string-with-props (car triple)))
+  (dolist (pair
+           '(
+             ("->0" . (0 . 28) )
+             ("##1" . (1 . 41) )
+             ))
+    (string-match (car pair) string-with-props)
+    (assert-equal (cddr pair)
+                  (realgud-loc-line-number (get-text-property
+                                            (match-beginning 0) 'loc
+                                            string-with-props)))
+
+    (assert-equal (cadr pair)
+                  (get-text-property
+                   (match-beginning 0) 'frame-num
+                   string-with-props))))
+
 (end-tests)


### PR DESCRIPTION
match-end and match-begin is overridden in realgud:file-loc-from-line.
It is better to store them in variables.