### PR TITLE
add eval at point and bind it to E in shortkey mode

### DIFF
--- a/realgud/common/cmds.el
+++ b/realgud/common/cmds.el
@@ -288,6 +288,11 @@ EVENT should be a mouse click on the left fringe or margin."
                           #'realgud:cmd-eval-region
                         #'realgud:cmd-eval)))
 
+(defun realgud:cmd-eval-at-point()
+  "Eval symbol under point."
+  (interactive)
+  (realgud:cmd-run-command (thing-at-point 'symbol) "eval"))
+
 (defun realgud:cmd-finish(&optional arg)
     "Run until the completion of the current stack frame.
 

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -62,6 +62,7 @@
     (define-key map "j"        'realgud:cmd-jump)
     (define-key map "c"        'realgud:cmd-continue)
     (define-key map "e"        'realgud:cmd-eval-dwim)
+    (define-key map "E"        'realgud:cmd-eval-at-point)
     (define-key map "U"        'realgud:cmd-until)
     (define-key map [mouse-2]  'realgud:tooltip-eval)
     (define-key map [left-fringe mouse-1] #'realgud-cmds--mouse-add-remove-bp)


### PR DESCRIPTION
a nice little shortcut in shortkey mode, when you hit E it will immediately eval whats under the point