### PR TITLE
extract method for breakpoint stuff in realgud:track-from-region

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -231,38 +231,38 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
 
       (if (not (equal "" text))
           (with-current-buffer cmdbuf
-	      (if (realgud-sget 'cmdbuf-info 'divert-output?)
-		  (realgud-track-divert-prompt text cmdbuf to))
-              ;; FIXME: instead of these fixed filters,
-	      ;; put into a list and iterate over that.
-	      (realgud-track-termination? text)
-	      (setq text-sans-loc (or (realgud-track-loc-remaining text) text))
-	      (realgud-track-bp-enable-disable text-sans-loc
-					       (realgud-cmdbuf-pat "brkpt-enable")
-					       't)
-	      (realgud-track-bp-enable-disable text-sans-loc
-					       (realgud-cmdbuf-pat "brkpt-disable")
-					       nil)
-	      (setq frame-num (realgud-track-selected-frame text))
-	      (if (and frame-num (not loc))
-		  (setq loc (realgud-track-loc-from-selected-frame
-			     text cmd-mark)))
+            (if (realgud-sget 'cmdbuf-info 'divert-output?)
+                (realgud-track-divert-prompt text cmdbuf to))
+            ;; FIXME: instead of these fixed filters,
+            ;; put into a list and iterate over that.
+            (realgud-track-termination? text)
+            (setq text-sans-loc (or (realgud-track-loc-remaining text) text))
+            (realgud-track-bp-enable-disable text-sans-loc
+                                             (realgud-cmdbuf-pat "brkpt-enable")
+                                             't)
+            (realgud-track-bp-enable-disable text-sans-loc
+                                             (realgud-cmdbuf-pat "brkpt-disable")
+                                             nil)
+            (setq frame-num (realgud-track-selected-frame text))
+            (if (and frame-num (not loc))
+                (setq loc (realgud-track-loc-from-selected-frame
+                           text cmd-mark)))
 
-              (realgud:track-add-breakpoint (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf) cmdbuf)
+            (realgud:track-add-breakpoint (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf) cmdbuf)
 
-	      (if loc
-		  (let ((selected-frame
-			 (or (not frame-num)
-			     (eq frame-num (realgud-cmdbuf-pat "top-frame-num")))))
-		    (realgud-track-loc-action loc cmdbuf (not selected-frame)
-                                              shortkey-on-tracing?)
-		    (realgud-cmdbuf-info-in-debugger?= 't)
-                    (realgud-cmdbuf-mode-line-update))
-                (realgud:track-remove-breakpoints
-                 (realgud-track-bp-delete text-sans-loc cmd-mark cmdbuf)))
-              )
-          )
+            (if loc
+                (let ((selected-frame
+                       (or (not frame-num)
+                           (eq frame-num (realgud-cmdbuf-pat "top-frame-num")))))
+                  (realgud-track-loc-action loc cmdbuf (not selected-frame)
+                                            shortkey-on-tracing?)
+                  (realgud-cmdbuf-info-in-debugger?= 't)
+                  (realgud-cmdbuf-mode-line-update))
+              (realgud:track-remove-breakpoints
+               (realgud-track-bp-delete text-sans-loc cmd-mark cmdbuf)))
+            )
         )
+      )
     )
   )
 

--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -223,18 +223,17 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
 	 ;; in frame-num. Otherwise, nil.
 	 (frame-num)
 	 (text-sans-loc)
-	 (bp-loc)
 	 (cmdbuf (or opt-cmdbuf (current-buffer)))
 	 )
     (unless (realgud:track-complain-if-not-in-cmd-buffer cmdbuf t)
       (if (realgud:eval-command-p text)
           (realgud:message-eval-results text))
 
-	(if (not (equal "" text))
-	    (with-current-buffer cmdbuf
+      (if (not (equal "" text))
+          (with-current-buffer cmdbuf
 	      (if (realgud-sget 'cmdbuf-info 'divert-output?)
 		  (realgud-track-divert-prompt text cmdbuf to))
-	      ;; FIXME: instead of these fixed filters,
+              ;; FIXME: instead of these fixed filters,
 	      ;; put into a list and iterate over that.
 	      (realgud-track-termination? text)
 	      (setq text-sans-loc (or (realgud-track-loc-remaining text) text))
@@ -249,13 +248,8 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
 		  (setq loc (realgud-track-loc-from-selected-frame
 			     text cmd-mark)))
 
-	      (setq bp-loc (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf))
-	      (if bp-loc
-		  (let ((src-buffer (realgud-loc-goto bp-loc)))
-		    (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)
-		    (with-current-buffer src-buffer
-		      (realgud-bp-add-info bp-loc)
-		      )))
+              (realgud:track-add-breakpoint (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf) cmdbuf)
+
 	      (if loc
 		  (let ((selected-frame
 			 (or (not frame-num)
@@ -264,17 +258,29 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
                                               shortkey-on-tracing?)
 		    (realgud-cmdbuf-info-in-debugger?= 't)
                     (realgud-cmdbuf-mode-line-update))
-                (dolist (bp-loc (realgud-track-bp-delete text-sans-loc cmd-mark cmdbuf))
-                  (let ((src-buffer (realgud-loc-goto bp-loc)))
-                    (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)
-                    (with-current-buffer src-buffer
-                      (realgud-bp-del-info bp-loc)
-                      ))))
+                (realgud:track-remove-breakpoints
+                 (realgud-track-bp-delete text-sans-loc cmd-mark cmdbuf)))
               )
           )
         )
     )
   )
+
+(defun realgud:track-add-breakpoint (bp-loc cmdbuf)
+  "Add a breakpoint fringe in source window if BP-LOC."
+  (if bp-loc
+      (let ((src-buffer (realgud-loc-goto bp-loc)))
+        (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)
+        (with-current-buffer src-buffer
+          (realgud-bp-add-info bp-loc)))))
+
+(defun realgud:track-remove-breakpoints (bp-locs cmdbuf)
+  "Remove all breakpoints in source window found in BP-LOCS."
+  (dolist (bp-loc bp-locs)
+    (let ((src-buffer (realgud-loc-goto bp-loc)))
+      (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)
+      (with-current-buffer src-buffer
+        (realgud-bp-del-info bp-loc)))))
 
 (defun realgud-track-hist-fn-internal(fn)
   "Update both command buffer and a source buffer to reflect the
@@ -582,7 +588,6 @@ of the breakpoints found in command buffer."
   ; that struct is the regexp hash to match positions. By setting the
   ; the fields of realgud-cmdbuf-info appropriately we can accomodate a
   ; family of debuggers -- one at a time -- for the buffer process.
-
   (setq cmdbuf (or cmdbuf (current-buffer)))
   (with-current-buffer cmdbuf
     (unless (realgud:track-complain-if-not-in-cmd-buffer cmdbuf t)


### PR DESCRIPTION
i was working on https://github.com/realgud/realgud/issues/180 and in an effort to understand what is going on I did an extract-method on two breakpoint related sections of realgud:track-from-region.  thought it was worth creating a pull request of it.

Do you remember what 
`	      (realgud-track-bp-enable-disable text-sans-loc
					       (realgud-cmdbuf-pat "brkpt-enable")
					       't)
	      (realgud-track-bp-enable-disable text-sans-loc
					       (realgud-cmdbuf-pat "brkpt-disable")
					       nil)
`
is suppose to do?  it seems like this might have the same purpose of the two methods i extracted, but perhaps they are for a different debugger?  When I commented them out I did not see any effect in realgud:pdb.