### PR TITLE
Move bps

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -237,18 +237,12 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
             ;; put into a list and iterate over that.
             (realgud-track-termination? text)
             (setq text-sans-loc (or (realgud-track-loc-remaining text) text))
-            (realgud-track-bp-enable-disable text-sans-loc
-                                             (realgud-cmdbuf-pat "brkpt-enable")
-                                             't)
-            (realgud-track-bp-enable-disable text-sans-loc
-                                             (realgud-cmdbuf-pat "brkpt-disable")
-                                             nil)
             (setq frame-num (realgud-track-selected-frame text))
             (if (and frame-num (not loc))
                 (setq loc (realgud-track-loc-from-selected-frame
                            text cmd-mark)))
 
-            (realgud:track-add-breakpoint (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf) cmdbuf)
+            (realgud:track-add-breakpoint text-sans-loc (realgud-track-bp-loc text-sans-loc cmd-mark cmdbuf) cmdbuf)
 
             (if loc
                 (let ((selected-frame
@@ -259,6 +253,7 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
                   (realgud-cmdbuf-info-in-debugger?= 't)
                   (realgud-cmdbuf-mode-line-update))
               (realgud:track-remove-breakpoints
+               text-sans-loc
                (realgud-track-bp-delete text-sans-loc cmd-mark cmdbuf)
                cmdbuf))
             )
@@ -267,16 +262,24 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
     )
   )
 
-(defun realgud:track-add-breakpoint (bp-loc cmdbuf)
+(defun realgud:track-add-breakpoint (text-sans-loc bp-loc cmdbuf)
   "Add a breakpoint fringe in source window if BP-LOC."
+  (realgud-track-bp-enable-disable text-sans-loc
+                                   (realgud-cmdbuf-pat "brkpt-enable")
+                                   't)
+
   (if bp-loc
       (let ((src-buffer (realgud-loc-goto bp-loc)))
         (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)
         (with-current-buffer src-buffer
           (realgud-bp-add-info bp-loc)))))
 
-(defun realgud:track-remove-breakpoints (bp-locs cmdbuf)
+(defun realgud:track-remove-breakpoints (text-sans-loc bp-locs cmdbuf)
   "Remove all breakpoints in source window found in BP-LOCS."
+  (realgud-track-bp-enable-disable text-sans-loc
+                                   (realgud-cmdbuf-pat "brkpt-disable")
+                                   nil)
+
   (dolist (bp-loc bp-locs)
     (let ((src-buffer (realgud-loc-goto bp-loc)))
       (realgud-cmdbuf-add-srcbuf src-buffer cmdbuf)

--- a/test/test-track.el
+++ b/test/test-track.el
@@ -10,6 +10,9 @@
 (load-file "../realgud/common/utils.el")
 (load-file "../realgud/debugger/trepan/core.el")
 (load-file "../realgud/debugger/trepan/init.el")
+(load-file "../realgud/debugger/pdb/core.el")
+(load-file "../realgud/debugger/pdb/init.el")
+(load-file "../realgud/debugger/pdb/track-mode.el")
 
 (declare-function __FILE__                                      'load-relative)
 (declare-function realgud-cmdbuf-init                           'realgud-buffer-command)
@@ -142,18 +145,20 @@ trepan: That's all, folks...
   (insert "if 1:\n    x = x + 1\n"))
 
 (setq test-buffer (find-file "test_file.py"))
-(realgud-cmdbuf-init test-buffer "trepan"
-		  (gethash "trepan" realgud-pat-hash))
+(realgud-cmdbuf-init test-buffer "pdb"
+		  (gethash "pdb" realgud-pat-hash))
 
 (setq bp-num 1)
-(setq debugger-bp-output (format "Breakpoint %d set at 	line %d\n\tin file %s."
-                                   bp-num 1 buffer-file-name))
+(setq debugger-bp-output (format "Breakpoint %d at %s:%d\n"
+                                 bp-num buffer-file-name 1))
+
+(setq debugger-bp-delete-output (format "Deleted breakpoint %d at %s:%d\n"
+                                        bp-num buffer-file-name 1))
 (save-excursion
-  (setq bp-loc (realgud-track-bp-loc debugger-bp-output nil))
   (let ((num-overlays (length (overlays-in 0 (point-max)))))
-    (realgud:track-add-breakpoint bp-loc test-buffer)
+    (realgud:track-add-breakpoint debugger-bp-output nil test-buffer)
     (assert-equal (+ 1 num-overlays) (length (overlays-in 0 (point-max))))
-    (realgud:track-remove-breakpoints (list bp-loc) (current-buffer))
+    (realgud:track-remove-breakpoints debugger-bp-delete-output nil test-buffer)
     (assert-equal num-overlays (length (overlays-in 0 (point-max))))))
 (kill-buffer "test_file.py")
 (delete-file "test_file.py")


### PR DESCRIPTION
i like moving these things down into the respective break point functions to move the level of abstraction up in realgud:track-from-region, but think it has the side effect of making the argument list to the two bp functions unfocused.  personally i think its worth it, what do you think?

also i think track-remove-breakpoints does not need to be in the else of the (if loc...  i tested this by moving it up to under the add-breakpoint call and everything appeared to run fine.