### PR TITLE
Add pprint to command hash

### DIFF
--- a/realgud/debugger/trepan3k/init.el
+++ b/realgud/debugger/trepan3k/init.el
@@ -114,6 +114,7 @@ realgud-loc-pat struct")
   the trepan3k command to use, like 'python'")
 
 (setf (gethash "eval"  realgud:trepan3k-command-hash) "eval %s")
+(setf (gethash "pprint" realgud:trepan3k-command-hash) "pp %s")
 (setf (gethash "shell" realgud:trepan3k-command-hash) "python")
 (setf (gethash "until" realgud-command-hash) "continue %l")
 


### PR DESCRIPTION
In my debug mode, I'd like hitting "p" on a symbol to pretty print its value in the debugger via realgud:cmd-run-command. For this, the command hash must include an entry for "pp".