### PR TITLE
configure.ac: Fix NO_CHECK_EMACS_PACKAGES elisp.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,8 +25,7 @@ AC_MSG_NOTICE("Checking prerequiste packages")
 $EMACS -batch -q --no-site-file -eval \
   '(dolist (package
          (quote (cl-lib loc-changes load-relative test-simple)))
-        (require package))
-   )'
+        (require package))'
 fi
 if test $? -ne 0 ; then
     AC_MSG_ERROR([Can't continue until above error is corrected.])


### PR DESCRIPTION
Hello!

This remove an extraneous trailing parenthesis in configure.ac.

I found the problem on GNU GuixSD which is now using Emacs 26; it seems older Emacs were more loose in evaluating the faulty Elisp snippet (as I didn't have this problem with Emacs 25 IIRC).

Thank you!
