### PR TITLE
change pdb to python -m pdb.

### DIFF
--- a/realgud/debugger/pdb/pdb.el
+++ b/realgud/debugger/pdb/pdb.el
@@ -35,7 +35,7 @@
 ;;
 
 (defcustom realgud:pdb-command-name
-  "pdb"
+  "python -m pdb"
   "File name for executing the stock Python debugger and command options.
 This should be an executable on your path, or an absolute file name."
   :type 'string


### PR DESCRIPTION
Hi,
when I use pdb, the system usually tells me that no "pdb" command under MacOS.
I need to manually change pdb to `python -m pdb` instead. 
I also notice that some others face the same problem.
Could you please help me with this PR?