### PR TITLE
gdb: handle ANSI escape codes, relative paths, blacklist, and doc fix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,8 +7,16 @@ Have `test-simple`, `loc-changes`, `cl-lib` and `load-relative` installed.
 From inside emacs, evaluate:
 
 ```lisp
-  (compile (format "EMACSLOADPATH=:%s:%s:%s:%s ./autogen.sh" (file-name-directory (locate-library "test-simple.elc")) (file-name-directory (locate-library "load-relative.elc")) (file-name-directory (locate-library "loc-changes.elc")) (file-name-directory (locate-library "realgud.elc")) ))
+  (compile (format "EMACSLOADPATH=:%s:%s:%s:%s ./autogen.sh" (file-name-directory (locate-library "test-simple.elc")) (file-name-directory (locate-library "load-relative.elc")) (file-name-directory (locate-library "loc-changes.elc")) default-directory) )
   ```
+
+
+Optional: if you want to install to a custom location, use ./configure as shown.
+Note, that --prefix does not prefix the lispdir, you must use --with-lispdir in
+addition to --prefix.
+
+    ./configure --prefix=INSTALL_DIR --with-lispdir=INSTALL_DIR/share/emacs/site-lisp
+
 
 After this you should be able to run:
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE
 
 AC_PATH_PROG([EMACS], [emacs], [emacs])
-AC_ARG_WITH(emacs, AC_HELP_STRING([--with-emacs],
+AC_ARG_WITH(emacs, AC_HELP_STRING([--with-emacs=VALUE],
                   [location of emacs program]), EMACS=$withval)
 
 AC_MSG_NOTICE("Checking emacs version")

--- a/realgud/common/file.el
+++ b/realgud/common/file.el
@@ -122,8 +122,8 @@ problem as best as we can determine."
 	  (setq matching-file-list (realgud--file-matching-suffix buffer-files filename))
 	  (car matching-file-list)))
 
-	;; Do we want to black-list this?
-	((y-or-n-p (format "Black-list file %s for location tracking?" filename))
+	;; Do we want to blacklist this?
+	((y-or-n-p (format "Unable to locate %s\nBlacklist it for location tracking?" filename))
 	 ;; FIXME: there has to be a simpler way to set ignore-file-list
 	 (with-current-buffer cmdbuf
 	   (push filename ignore-re-file-list)

--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -47,43 +47,44 @@
   :type 'symbolp
   :group 'realgud)
 
-(declare-function buffer-killed?                      'realgud-helper)
-(declare-function fn-p-to-fn?-alias                   'realgud-helper)
-(declare-function realgud-bp-add-info                 'realgud-bp)
-(declare-function realgud-bp-del-info                 'realgud-bp)
-(declare-function realgud-bp-enable-disable-info      'realgud-bp)
-(declare-function realgud-cmdbuf-add-srcbuf           'realgud-buffer-command)
-(declare-function realgud-cmdbuf-debugger-name        'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-bp-list=        'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-divert-output?= 'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-in-debugger?    'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-in-debugger?=   'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-last-input-end= 'realgud-buffer-command)
-(declare-function realgud-cmdbuf-init                 'realgud-buffer-command)
-(declare-function realgud-cmdbuf-loc-hist             'realgud-buffer-command)
-(declare-function realgud-cmdbuf-mode-line-update     'realgud-buffer-command)
-(declare-function realgud-cmdbuf-mode-line-update     'realgud-buffer-command)
-(declare-function realgud-cmdbuf-pat                  'realgud-buffer-command)
-(declare-function realgud-cmdbuf?                     'realgud-buffer-command)
-(declare-function realgud-cmdbuf-info-in-srcbuf?=     'realgud-buffer-command)
-(declare-function realgud:debugger-name-transform     'realgud-helper)
-(declare-function realgud:terminate                   'realgud-core)
-(declare-function realgud:file-loc-from-line          'realgud-file)
-(declare-function realgud-fringe-history-set          'realgud-fringe)
-(declare-function realgud-get-cmdbuf                  'realgud-buffer-command)
-(declare-function realgud-get-srcbuf-from-cmdbuf      'realgud-buffer-helper)
-(declare-function realgud-loc-goto                    'realgud-loc)
-(declare-function realgud-loc-hist-add                'realgud-lochist)
-(declare-function realgud-loc-hist-index              'realgud-lochist)
-(declare-function realgud-loc-hist-item               'realgud-lochist)
-(declare-function realgud-loc?                        'realgud-loc)
-(declare-function realgud-short-key-mode-setup        'realgud-shortkey)
-(declare-function realgud-srcbuf-init-or-update       'realgud-source)
-(declare-function realgud-srcbuf-loc-hist             'realgud-source)
-(declare-function realgud-window-src                  'realgud-window)
-(declare-function realgud-window-src-undisturb-cmd    'realgud-window)
-(declare-function realgud-window-update-position      'realgud-window)
-(declare-function realgud:join-string                 'realgud-utils)
+(declare-function buffer-killed?                        'realgud-helper)
+(declare-function fn-p-to-fn?-alias                     'realgud-helper)
+(declare-function realgud-bp-add-info                   'realgud-bp)
+(declare-function realgud-bp-del-info                   'realgud-bp)
+(declare-function realgud-bp-enable-disable-info        'realgud-bp)
+(declare-function realgud-cmdbuf-add-srcbuf             'realgud-buffer-command)
+(declare-function realgud-cmdbuf-debugger-name          'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-bp-list=          'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-divert-output?=   'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-in-debugger?      'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-in-debugger?=     'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-last-input-end=   'realgud-buffer-command)
+(declare-function realgud-cmdbuf-init                   'realgud-buffer-command)
+(declare-function realgud-cmdbuf-loc-hist               'realgud-buffer-command)
+(declare-function realgud-cmdbuf-mode-line-update       'realgud-buffer-command)
+(declare-function realgud-cmdbuf-mode-line-update       'realgud-buffer-command)
+(declare-function realgud-cmdbuf-pat                    'realgud-buffer-command)
+(declare-function realgud-cmdbuf?                       'realgud-buffer-command)
+(declare-function realgud-cmdbuf-info-in-srcbuf?=       'realgud-buffer-command)
+(declare-function realgud:debugger-name-transform       'realgud-helper)
+(declare-function realgud:terminate                     'realgud-core)
+(declare-function realgud:file-loc-from-line            'realgud-file)
+(declare-function realgud-fringe-history-set            'realgud-fringe)
+(declare-function realgud-get-cmdbuf                    'realgud-buffer-command)
+(declare-function realgud-get-srcbuf-from-cmdbuf        'realgud-buffer-helper)
+(declare-function realgud-loc-goto                      'realgud-loc)
+(declare-function realgud-loc-hist-add                  'realgud-lochist)
+(declare-function realgud-loc-hist-index                'realgud-lochist)
+(declare-function realgud-loc-hist-item                 'realgud-lochist)
+(declare-function realgud-loc?                          'realgud-loc)
+(declare-function realgud-short-key-mode-setup          'realgud-shortkey)
+(declare-function realgud-srcbuf-init-or-update         'realgud-source)
+(declare-function realgud-srcbuf-loc-hist               'realgud-source)
+(declare-function realgud-window-src                    'realgud-window)
+(declare-function realgud-window-src-undisturb-cmd      'realgud-window)
+(declare-function realgud-window-update-position        'realgud-window)
+(declare-function realgud:join-string                   'realgud-utils)
+(declare-function realgud:remove-ansi-schmutz-in-string 'realgud-utils)
 
 (make-variable-buffer-local  (defvar realgud-track-mode))
 (fn-p-to-fn?-alias 'realgud-loc-p)
@@ -228,18 +229,7 @@ evaluating (realgud-cmdbuf-info-loc-regexp realgud-cmdbuf-info)"
 
   (interactive "r")
   (if (> from to) (cl-psetq to from from to))
-  (let* ((text (replace-regexp-in-string
-                ;; Strip ANSI escape codes, e.g. gdb produces ^[[?2004h and ^[[?2004l before
-                ;; prompts. This regex handles these sequences, colors, and more. However, it
-                ;; doesn't cover all. To cover all, we'd need something like
-                ;; "\033\\[\\??[0-9;]*[a-zA-Z]" but this covers non-defined escape sequences and is
-                ;; missing sequences that have multiple ending letters. The multi-letter ending
-                ;; escape sequences probably won't occur because these are cursor movement
-                ;; sequences. Examining the escape code spec, this regex should cover all cases
-                ;; we'd hit from a debugger.
-                ;; https://github.com/realgud/realgud/issues/257
-                ;; https://en.wikipedia.org/wiki/ANSI_escape_code
-                "\033\\[\\??[0-9;]*[CDGKJhlm]" ""
+  (let* ((text (realgud:remove-ansi-schmutz-in-string
                 (buffer-substring-no-properties from to)))
 	 (loc (realgud-track-loc text cmd-mark))
 	 ;; If we see a selected frame number, it is stored

--- a/realgud/common/utils.el
+++ b/realgud/common/utils.el
@@ -53,6 +53,21 @@ Or raise an error if neither."
 	('t (error "We can only handle comint, shell, or eshell buffers"))
 	))
 
+(defun realgud:remove-ansi-schmutz-in-string (string)
+  "Remove ASCII escape sequences from STRING"
+  (replace-regexp-in-string
+   ;; Strip ANSI escape codes, e.g. gdb produces ^[[?2004h and ^[[?2004l before
+   ;; prompts. This regex handles these sequences, colors, and more. However, it
+   ;; doesn't cover all. To cover all, we'd need something like
+   ;; "\033\\[\\??[0-9;]*[a-zA-Z]" but this covers non-defined escape sequences and is
+   ;; missing sequences that have multiple ending letters. The multi-letter ending
+   ;; escape sequences probably won't occur because these are cursor movement
+   ;; sequences. Examining the escape code spec, this regex should cover all cases
+   ;; we'd hit from a debugger.
+   ;; https://github.com/realgud/realgud/issues/257
+   ;; https://en.wikipedia.org/wiki/ANSI_escape_code
+   "\033\\[\\??[0-9;]*[CDGKJhlm]" "" string))
+
 (defun realgud:remove-ansi-schmutz()
   "Remove ASCII escape sequences that node.js 'decorates' in
 prompts and interactive output with"
@@ -60,7 +75,7 @@ prompts and interactive output with"
   (add-to-list
    'comint-preoutput-filter-functions
    (lambda (output)
-     (replace-regexp-in-string "\033\\[[0-9]*[CDGKJhl]" "" output)))
+     (realgud:remove-ansi-schmutz-in-string output)))
   )
 
 

--- a/realgud/debugger/gdb/gdb.el
+++ b/realgud/debugger/gdb/gdb.el
@@ -134,6 +134,14 @@ fringe and marginal icons.
 	  (if (and process (eq 'run (process-status process)))
 	      (with-current-buffer cmd-buf
 		(realgud-command "set annotate 1" nil nil nil)
+                ;; In gdb, when setting breakpoint on function, we want it to produce an absolute
+                ;; path, so set filename-display to absolute. We want:
+                ;;   (gdb) b functionName
+                ;;   Breakpoint 1 at 0x7fff607e4dd6: file /abs/path/to/file.cpp, line 273.
+                ;; Without this, gdb will display the path supplied when the code was compiled, i.e.
+                ;; if a relative path is supplied to gcc, gdb will display the relative path
+                ;; tripping up realgud, causing it to ask if you want to blacklist the file.
+                (realgud-command "set filename-display absolute" nil nil nil)
 		)))
       )
     ))

--- a/test/test-utils.el
+++ b/test/test-utils.el
@@ -50,4 +50,9 @@
 ;;   (assert-equal 'comint (realgud:canonic-major-mode))
 ;;   )
 
+(note "realgud:remove-ansi-schmutz-in-string")
+(assert-equal "(gdb) " (realgud:remove-ansi-schmutz-in-string "[?2004h[?2004l[?2004h(gdb) "))
+(assert-equal "color" (realgud:remove-ansi-schmutz-in-string "[30;46mcolor[0m"))
+
+
 (end-tests)


### PR DESCRIPTION
1. track.el: gdb will generate ANSI escape sequences (emacs 25, Debian 9, gdb 7.12) into the comint
   buffer which was causing the regex matches to fail resulting in no location tracking. Fix by
   stripping the ANSI escape sequences when we extract the buffer text from the comint buffer.

2. gdb.el: When setting a breakpoint to a function, gdb by default displays a relative path, e.g.
     (gdb) b functionName
      Breakpoint 1 at 0x7fff607e4dd6: file dir/file.cpp, line 273.
   where dir/file.cpp is relative which occurs when you compile using a relative path,
   g++ -c dir/file.cpp
   We want it to display
      (gdb) b functionName
      Breakpoint 1 at 0x7fff607e4dd6: file /abs/path/to/file.cpp, line 273.
   which is achieved by setting "set filename-display absolute" at gdb startup.

3. file.el: Improve the prompt on file blacklist to indicate why blacklisting is occurring, i.e. the
   file is not found. (Also fix typo, black-list is spelled blacklist).

4. Minor doc fixes on how to use ./configure.