### PR TITLE
debuggers: Fix void realgud:run-process error in gdb and gub.

### DIFF
--- a/realgud/debugger/gdb/gdb.el
+++ b/realgud/debugger/gdb/gdb.el
@@ -22,6 +22,9 @@
 			 "../../common/utils")
 		       "realgud-")
 
+(require-relative-list '("../../common/run")
+                       "realgud:")
+
 (require-relative-list '("../../common/buffer/command"
 			 "../../common/buffer/source")
 		       "realgud-buffer-")
@@ -55,7 +58,7 @@ This should be an executable on your path, or an absolute file name."
 (declare-function realgud-command            'realgud:cmds)
 (declare-function realgud:gdb-parse-cmd-args 'realgud:gdb-core)
 (declare-function realgud:gdb-query-cmdline  'realgud:gdb-core)
-(declare-function realgud:run-process        'realgud-core)
+(declare-function realgud:run-process        'realgud:run)
 (declare-function realgud:flatten            'realgud-utils)
 
 ;; -------------------------------------------------------------------

--- a/realgud/debugger/gub/gub.el
+++ b/realgud/debugger/gub/gub.el
@@ -20,6 +20,7 @@
 (require-relative-list '("../../common/helper") "realgud-")
 (require-relative-list '("../../common/track") "realgud-")
 (require-relative-list '("core" "track-mode") "realgud:gub-")
+(require-relative-list '("../../common/run") "realgud:")
 
 (eval-when-compile (require 'cl-lib))
 
@@ -43,7 +44,7 @@ This should be an executable on your path, or an absolute file name."
 
 (declare-function gub-query-cmdline  'realgud-gub-core)
 (declare-function gub-parse-cmd-args 'realgud-gub-core)
-(declare-function realgud:run-process 'realgud-core)
+(declare-function realgud:run-process 'realgud:run)
 
 
 (defun realgud-gub-fn (&optional opt-command-line no-reset)

--- a/realgud/debugger/pdb/pdb.el
+++ b/realgud/debugger/pdb/pdb.el
@@ -48,7 +48,7 @@ This should be an executable on your path, or an absolute file name."
 (declare-function pdb-query-cmdline    'realgud:pdb-core)
 (declare-function pdb-parse-cmd-args   'realgud:pdb-core)
 (declare-function realgud:run-debugger 'realgud:run)
-(declare-function realgud:run-process  'realgud:core)
+(declare-function realgud:run-process  'realgud:run)
 (declare-function realgud:flatten      'realgud-utils)
 
 ;;;###autoload

--- a/realgud/debugger/trepan2/trepan2.el
+++ b/realgud/debugger/trepan2/trepan2.el
@@ -27,7 +27,7 @@
 (declare-function trepan2-parse-cmd-args 'realgud:trepan2-core)
 (declare-function trepan2-track-mode     'realgud:pydbgr-track-mode)
 (declare-function realgud:run-debugger   'realgud:run)
-(declare-function realgud:run-process  'realgud:core)
+(declare-function realgud:run-process  'realgud:run)
 (declare-function realgud:flatten      'realgud-utils)
 
 ;; -------------------------------------------------------------------

--- a/realgud/debugger/trepan3k/trepan3k.el
+++ b/realgud/debugger/trepan3k/trepan3k.el
@@ -24,7 +24,7 @@
 (declare-function trepan3k-query-cmdline  'realgud:trepan3k-core)
 (declare-function trepan3k-parse-cmd-args 'realgud:trepan3k-core)
 (declare-function realgud:run-debugger    'realgud:run)
-(declare-function realgud:run-process     'realgud:core)
+(declare-function realgud:run-process     'realgud:run)
 (declare-function realgud:flatten         'realgud-utils)
 
 ;; -------------------------------------------------------------------


### PR DESCRIPTION
Fixes <https://github.com/realgud/realgud/issues/269>.

The 'realgud:run-process' function was not defined in the context of
the gdb and gub debuggers, causing an error when running 'M-x
realgud:gdb', for example.

These are the important bits that fix the above problem:

* realgud/debugger/gdb/gdb.el: Require "../../common/run".
* realgud/debugger/gub/gub.el: Likewise.

The following changes are cosmetic, non-functional:

* realgud/debugger/gdb/gdb.el (realgud:run-process): Fix "file"
reference.
* realgud/debugger/gub/gub.el (realgud:run-process): Likewise.
* realgud/debugger/pdb/pdb.el (realgud:run-process): Likewise.
* realgud/debugger/trepan2/trepan2.el (realgud:run-process): Likewise.
* realgud/debugger/trepan3k/trepan3k.el (realgud:run-process): Likewise.