### PR TITLE
Add proper cleanup for locals. Fix broken logic from b5ee91c.

### DIFF
--- a/realgud/common/buffer/locals.el
+++ b/realgud/common/buffer/locals.el
@@ -29,7 +29,6 @@
 (cl-defstruct realgud-locals-info
   "debugger object/structure specific to a (top-level) program to be debugged."
   (cmdbuf    nil)  ;; buffer of the associated debugger process
-  (srcbuf    nil)  ;; associated source buffer
   )
 (make-variable-buffer-local (defvar realgud-locals-info))
 
@@ -66,29 +65,30 @@ ARGS - arguments for command"
 
 (defun realgud-locals-init ()
   "Create locals buffer and fill it for first time."
-  (let ((cmdbuf (realgud-get-cmdbuf))
-	(srcbuf (realgud-get-srcbuf)))
+  (let ((cmdbuf (realgud-get-cmdbuf)) )
     (with-current-buffer-safe cmdbuf
       (let ((locals-buffer (get-buffer-create
 			    (format "*locals %s*"
 				    (realgud-get-buffer-base-name
 				     (buffer-name))))))
 	(realgud-cmdbuf-info-locals-buf= locals-buffer)
-	(with-current-buffer-safe (realgud-get-srcbuf)
+	(with-current-buffer-safe (realgud-get-cmdbuf)
+	  ;; Hook loc change for autorefresh.
 	  (add-hook 'realgud-update-hook 'realgud:window-locals nil t) )
 	(with-current-buffer locals-buffer
 	  (realgud-locals-mode) ; It kills local variables
-	  (add-hook 'kill-buffer-hook
-		    (lambda ()
-		      (with-current-buffer-safe (realgud-sget 'locals-info 'srcbuf)
-			(remove-hook 'realgud-update-hook 'realgud:window-locals t) )) nil t)
+	  (add-hook 'kill-buffer-hook 'realgud-locals-terminate)
 	  (setq realgud-buffer-type 'locals)
 	  (set (make-local-variable 'realgud-locals-info)
 	       (make-realgud-locals-info
-		:cmdbuf cmdbuf
-		:srcbuf srcbuf)) )
+		:cmdbuf cmdbuf)) )
 	(realgud-locals-register-reload)
 	(realgud-locals-insert) ))))
+
+(defun realgud-locals-terminate (&optional buf)
+  (with-current-buffer (or buf (current-buffer))
+    (with-current-buffer-safe (realgud-get-cmdbuf)
+      (remove-hook 'realgud-update-hook 'realgud:window-locals t) )))
 
 (defun realgud-locals-get-variable-data (local-var-name)
   "Return list with type and value of variable, in that order.

--- a/realgud/common/core.el
+++ b/realgud/common/core.el
@@ -29,6 +29,7 @@
 (declare-function realgud-cmdbuf-command-string       'realgud-buffer-command)
 (declare-function realgud-cmdbuf-debugger-name        'realgud-buffer-command)
 (declare-function realgud-cmdbuf-info-bp-list=        'realgud-buffer-command)
+(declare-function realgud-locals-terminate            'realgud-locals)
 (declare-function realgud-cmdbuf-info-in-debugger?=   'realgud-buffer-command)
 (declare-function realgud-cmdbuf-info-starting-directory= 'realgud-buffer-command)
 (declare-function realgud-cmdbuf-mode-line-update     'realgud-buffer-command)
@@ -159,6 +160,7 @@ icons and resets short-key mode."
   (let ((cmdbuf (realgud-get-cmdbuf buf)))
     (if cmdbuf
 	(with-current-buffer cmdbuf
+	  (realgud-locals-terminate)
 	  (realgud-cmdbuf-info-in-debugger?= nil)
 	  (realgud-cmdbuf-info-bp-list= '())
 	  (realgud-cmdbuf-mode-line-update)

--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -435,7 +435,7 @@ encountering a new loc."
 	    (realgud-cmdbuf-info-in-srcbuf?= nil))
 	  )
 	))
-  (with-current-buffer-safe (realgud-get-srcbuf)
+  (with-current-buffer-safe (realgud-get-cmdbuf)
     (run-hooks 'realgud-update-hook) )
   )
 


### PR DESCRIPTION
Locals buffer will not auto-recreate after being killed.
Autorefresh will work now after switching to new srcbuf.