### PR TITLE
Fix focus lose in source buffer after invoking debugger command.

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -421,8 +421,7 @@ encountering a new loc."
 		      ;; 				'realgud-overlay-arrow1)
 		      ;; 	)
 		      (realgud-window-update-position srcbuf realgud-overlay-arrow1)))
-		)
-	      (if cmd-window (select-window cmd-window)))
+		))
 	  ; else
 	  (with-current-buffer srcbuf
 	    (realgud-window-src srcbuf)


### PR DESCRIPTION
Fixes https://github.com/realgud/realgud/issues/289

Hi,
    Thanks for RealGUD. RealGUD's "short-key mode" is a nice replacement for gdb's "TUI Single Key Mode".

Removing the line https://github.com/realgud/realgud/blob/962b5af40c8970d09581613d67b1a5d99eaa39e7/realgud/common/track.el#L425 fixes the issue. The function containing that line is called by the "realgud-track-comint-output-filter-hook" which is added to the list of "comint-output-filter-functions".


This bug is not entirely deterministic. This bug is more likely to occur when the debugger command produces delayed output.

To reproduce this issue execute the following elisp code which creates a test python file containing code to delay the output and runs the realgud on the file

```
(progn
  (with-temp-file "/tmp/test2.py"
    (insert "
import time
print(\"hello\")
time.sleep(3)
print(\"world\")
"))
  (realgud:pdb "python -m pdb /tmp/test2.py")
  )
```

Then call the following function when the focus is on the "test2.py" buffer. The  function **send-next-until-focus-lost** keep calling python debugger "next" command  until this issue occur's. ie. until test2.py loses focus.

```
(defun send-next-until-focus-lost()
  (interactive)
  "keep sending next command to cmd buffer *pdb test2.py shell* until the focus is lost"

  (if (eq (get-buffer "test2.py") (window-buffer (selected-window)))
      (progn
	(with-current-buffer "*pdb test2.py shell*"
	  (insert "next")
	  (comint-send-input))
	(run-at-time "5 sec" nil #'send-next-until-focus-lost)
	)
  (message "focus lost on buffer test2.py")))

```

This line that's causing the issue has been added during the creation of the file "realgud/common/track.el" in the commit https://github.com/realgud/realgud/commit/17fdf2678ad30d47f4ce0b422f008a0e7c9a42a1. I could not find the reason to why this line was added. 

I verified this patch using the same above elisp function used to reproduce the issue. The issue was not seen after applying the patch and running the command **send-next-until-focus-lost** for couple of hours. All the existing tests passed with the patch(ie. "make check").

This issue is most likely fixes the following issues
https://github.com/realgud/realgud/issues/260
https://github.com/realgud/realgud/issues/225
https://github.com/realgud/realgud/issues/50

Thanks,
Frank
