### PR TITLE
Revert "Fix focus lose in source buffer after invoking debugger command."

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -421,7 +421,8 @@ encountering a new loc."
 		      ;; 				'realgud-overlay-arrow1)
 		      ;; 	)
 		      (realgud-window-update-position srcbuf realgud-overlay-arrow1)))
-		))
+		)
+	      (if cmd-window (select-window cmd-window)))
 	  ; else
 	  (with-current-buffer srcbuf
 	    (realgud-window-src srcbuf)


### PR DESCRIPTION
Reverts realgud/realgud#293

@yberfrankc I've been trying this for the last week or so and the experience I get debugging Python is worse, it is not tracking source code locations enough to be annoying. 

(It may be that for gdb though this is better). At any rate we need something better than this and until such time when we have more people actively working on this my use takes precedence over broken behavior. 