### PR TITLE
Include "comint-mode-map" bindings in "realgud-track-mode-map".

### DIFF
--- a/realgud/common/track-mode.el
+++ b/realgud/common/track-mode.el
@@ -45,6 +45,7 @@
 
 (defvar realgud-track-mode-map
   (let ((map  (copy-keymap shell-mode-map)))
+    (set-keymap-parent map comint-mode-map)
     (realgud-populate-debugger-menu map)
     (define-key map "\r"	'realgud:send-input)
     (define-key map [M-right]	'realgud-track-hist-newest)


### PR DESCRIPTION
In Emacs-26 "realgud-track-mode-map" had the keybindings of "comint-mode-map". This was accomplished
indirectly by copying the "shell-mode-map" which in turn copied from "comint-mode-map".

In Emacs-27 "shell-mode-map" no longer copies the "comint-mode-map" and this broke the
"realgud-track-mode-map"(https://github.com/emacs-mirror/emacs/commit/1204e7cb81093a42b781eb8c083af9d406de23e9)

To fix set the "comint-mode-map" as parent keymap.

Fixes https://github.com/realgud/realgud/issues/290