### PR TITLE
gdb: Add support for detecting deleted breakpoints

### DIFF
--- a/realgud/debugger/gdb/gdb.el
+++ b/realgud/debugger/gdb/gdb.el
@@ -145,6 +145,9 @@ fringe and marginal icons.
                 ;; if a relative path is supplied to gcc, gdb will display the relative path
                 ;; tripping up realgud, causing it to ask if you want to blacklist the file.
                 (realgud-command "set filename-display absolute" nil nil nil)
+                ;; gdb doesn't print a confirmation that a breakpoint was deleted successfully by default.
+                ;; This event listener adds a status message for every deleted breakpoint.
+                (realgud-command "python gdb.events.breakpoint_deleted.connect(lambda b: print(f\"Deleted breakpoint {b.number}\"))" nil nil nil)
 		)))
       )
     ))

--- a/realgud/debugger/gdb/init.el
+++ b/realgud/debugger/gdb/init.el
@@ -79,10 +79,13 @@ realgud-loc-pat struct")
 ;; response.
 ;; For example:
 ;;   Deleted breakpoint 1
+;;   Deleted breakpoint 1 Deleted breakpoint 1
 ;;   Deleted breakpoints 1 2 3 4
+;; The event listener seems to trigger twice when a breakpoint is deleted using the
+;; clear command. The regexp works around this by allowing one repetition of the match.
 (setf (gethash "brkpt-del" realgud:gdb-pat-hash)
       (make-realgud-loc-pat
-       :regexp "^Deleted breakpoints? \\(\\([0-9]+ *\\)+\\)\n"
+       :regexp "^\\(?:Deleted breakpoints? \\(\\([0-9]+ *\\)+\\) *\\)\\{1,2\\}\n"
        :num 1))
 
 (defconst realgud:gdb-frame-start-regexp


### PR DESCRIPTION
Added the change below.

This change depends on gdb having python support, which is a small breaking change.

I haven't tested if the changes intefere with other debugger configurations.

I dabbled with using the `--interpreter mi3` option before settling on this solution.
Using the GDB/MI seems to be a lot cleaner but this would require a few major architectural changes to realgud and would break a few features like attaching to a running gdb session (I don't know of a way to enable the mi at runtime) and eshell support (as realgud would have to rewrite the command buffer).

> Added a python event listener that prints a message whenever a
> breakpoint is deleted.
>
> The regexp for detecting deleted breakpoints is now applied repeatedly
> as long as there are additional matches as the gdb listener writes
> one message for each deleted breakpoint.
>
> This should fix #278, #180 and #61.