### PR TITLE
(gdb) use variable to hold commands to be executed after command buff…

### DIFF
--- a/realgud/debugger/gdb/gdb.el
+++ b/realgud/debugger/gdb/gdb.el
@@ -54,6 +54,19 @@ This should be an executable on your path, or an absolute file name."
   :type 'string
   :group 'realgud:gdb)
 
+(defvar realgud:gdb-init-commands
+  '("set annotate 1"
+    ;; In gdb, when setting breakpoint on function, we want it to produce an absolute
+    ;; path, so set filename-display to absolute. We want:
+    ;;   (gdb) b functionName
+    ;;   Breakpoint 1 at 0x7fff607e4dd6: file /abs/path/to/file.cpp, line 273.
+    ;; Without this, gdb will display the path supplied when the code was compiled, i.e.
+    ;; if a relative path is supplied to gcc, gdb will display the relative path
+    ;; tripping up realgud, causing it to ask if you want to blacklist the file.
+    "set filename-display absolute"
+    )
+  "List of commands to be executed right after command buffer setup.")
+
 (declare-function realgud:gdb-track-mode     'realgud:gdb-track-mode)
 (declare-function realgud-command            'realgud:cmds)
 (declare-function realgud:gdb-parse-cmd-args 'realgud:gdb-core)
@@ -136,18 +149,9 @@ fringe and marginal icons.
 	(let ((process (get-buffer-process cmd-buf)))
 	  (if (and process (eq 'run (process-status process)))
 	      (with-current-buffer cmd-buf
-		(realgud-command "set annotate 1" nil nil nil)
-                ;; In gdb, when setting breakpoint on function, we want it to produce an absolute
-                ;; path, so set filename-display to absolute. We want:
-                ;;   (gdb) b functionName
-                ;;   Breakpoint 1 at 0x7fff607e4dd6: file /abs/path/to/file.cpp, line 273.
-                ;; Without this, gdb will display the path supplied when the code was compiled, i.e.
-                ;; if a relative path is supplied to gcc, gdb will display the relative path
-                ;; tripping up realgud, causing it to ask if you want to blacklist the file.
-                (realgud-command "set filename-display absolute" nil nil nil)
-		)))
-      )
-    ))
+                (dolist (it realgud:gdb-init-commands)
+                  (realgud-command it nil nil nil))))))
+    cmd-buf))
 
 (provide-me "realgud-")
 


### PR DESCRIPTION
…er setup

User can either bind this variable on the fly, or set it directly in the init file.

And `realgud:gdb` now returns command buffer now, so user can do something with this buffer.