### PR TITLE
Escape the escape characters for message

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -212,7 +212,7 @@ message."
 
 (defun realgud:message-eval-results(text)
   "Output the TEXT to the message area."
-  (message (realgud:truncate-eval-message (realgud:get-eval-output text))))
+  (message "%s" (realgud:truncate-eval-message (realgud:get-eval-output text))))
 
 (defun realgud:track-from-region(from to &optional cmd-mark opt-cmdbuf
 				      shortkey-on-tracing? no-warn-if-no-match?)


### PR DESCRIPTION
If the eval message contains the chacater "%", then the call to message will error, because it's expecting format-string arguments. 

The recommended way to escape strings passed to message (according to `message's docstring) is to do the following: 

(message %s "the-string-%")