### PR TITLE
Fix breakpoint tracking for gdb

### DIFF
--- a/realgud/common/track.el
+++ b/realgud/common/track.el
@@ -687,8 +687,7 @@ of the breakpoints found in command buffer."
                      (bp-num-strs (split-string bp-nums-str "[^0-9]+" t))
                      (bp-nums (mapcar #'string-to-number bp-num-strs))
                      (info realgud-cmdbuf-info)
-                     (all-bps (realgud-cmdbuf-info-bp-list info))
-                     (found-locs nil))
+                     (all-bps (realgud-cmdbuf-info-bp-list info)))
                 (dolist (loc all-bps)
                   (when (memq (realgud-loc-num loc) bp-nums)
                     (push loc found-locs)
@@ -696,9 +695,9 @@ of the breakpoints found in command buffer."
                     (realgud-cmdbuf-info-bp-list=
                      (remove loc (realgud-cmdbuf-info-bp-list info)))))
                 (setq current-pos (match-end 0))))
-                ;; Match-end returns 0 when the whole string was matched.
-                ;; Setting current-pos to nil exits the loop
-                (if (= current-pos 0) (setq current-pos nil))
+            ;; Match-end returns 0 when the whole string was matched.
+            ;; Setting current-pos to nil exits the loop
+            (if (= current-pos 0) (setq current-pos nil))
             ;; return the locations
             found-locs))))))
 

--- a/realgud/debugger/gdb/gdb.el
+++ b/realgud/debugger/gdb/gdb.el
@@ -66,7 +66,7 @@ This should be an executable on your path, or an absolute file name."
     "set filename-display absolute"
     ;; gdb doesn't print a confirmation that a breakpoint was deleted successfully by default.
     ;; This event listener adds a status message for every deleted breakpoint.
-    (realgud-command "python gdb.events.breakpoint_deleted.connect(lambda b: print(f\"Deleted breakpoint {b.number}\"))" nil nil nil)
+    "python gdb.events.breakpoint_deleted.connect(lambda b: print(f\"Deleted breakpoint {b.number}\"))"
     )
   "List of commands to be executed right after command buffer setup.")
 


### PR DESCRIPTION
With the new gdb python event listener, the breakpoint deletion regexp has changed. Update the regexp so that gdb can remove overlays.

I also found a bug in track.el while fixing this, where `found-locs` is let-declared an extra time, causing `realgud-track-bp-delete` to return `nil` even though it was able to find some `realgud-loc`s.