### PR TITLE
Fix cl-remove-if 'nil

### DIFF
--- a/realgud/common/run.el
+++ b/realgud/common/run.el
@@ -191,7 +191,7 @@ Otherwise nil is returned.
 	 (script-args (cl-caddr parsed-args))
 	 (script-name (or opt-script-name (car script-args)))
 	 (parsed-cmd-args
-	  (cl-remove-if 'nil (realgud:flatten parsed-args)))
+	  (cl-remove-if #'null (realgud:flatten parsed-args)))
 	 )
     (realgud:run-process debugger-name script-name parsed-cmd-args
 			 minibuffer-history no-reset)

--- a/realgud/debugger/pdb/pdb.el
+++ b/realgud/debugger/pdb/pdb.el
@@ -126,7 +126,7 @@ Therefore we invoke python rather than the debugger initially.
 	 (script-args (nth 1 parsed-args))
 	 (script-name (car script-args))
 	 (parsed-cmd-args
-	  (cl-remove-if 'nil (realgud:flatten parsed-args))))
+	  (cl-remove-if #'null (realgud:flatten parsed-args))))
     (realgud:run-process actual-debugger script-name parsed-cmd-args
 			 'realgud:pdb-minibuffer-history)))
 

--- a/realgud/debugger/trepan2/trepan2.el
+++ b/realgud/debugger/trepan2/trepan2.el
@@ -94,7 +94,7 @@ Therefore we invoke python rather than the debugger initially.
 	 (script-args (nth 1 parsed-args))
 	 (script-name (car script-args))
 	 (parsed-cmd-args
-	  (cl-remove-if 'nil (realgud:flatten parsed-args))))
+	  (cl-remove-if #'null (realgud:flatten parsed-args))))
     (realgud:run-process actual-debugger script-name parsed-cmd-args
 			 'realgud:trepan2-minibuffer-history)))
 

--- a/realgud/debugger/trepan3k/trepan3k.el
+++ b/realgud/debugger/trepan3k/trepan3k.el
@@ -91,7 +91,7 @@ Therefore we invoke python rather than the debugger initially.
 	 (script-args (nth 1 parsed-args))
 	 (script-name (car script-args))
 	 (parsed-cmd-args
-	  (cl-remove-if 'nil (realgud:flatten parsed-args))))
+	  (cl-remove-if #'null (realgud:flatten parsed-args))))
     (realgud:run-process actual-debugger script-name parsed-cmd-args
 			 'realgud:trepan3k-delayed-minibuffer-history)))
 


### PR DESCRIPTION
**'nil** is not a predicat, and this function doesn't work on the latest emacs 31.

To reproduce I'm using **realgud:pdb**, that produce a stacktrace

```
Debugger entered--Lisp error: (void-function nil)
  nil("python")
  funcall(nil "python")
  cl-remove(nil ("python" "-m" "pdb" "/var/home/arouene/tmp2/fib.py") :test funcall)
  cl-remove-if(nil ("python" "-m" "pdb" "/var/home/arouene/tmp2/fib.py"))
  realgud:run-debugger("pdb" pdb-query-cmdline pdb-parse-cmd-args realgud:pdb-minibuffer-history nil nil)
  realgud:pdb()
  funcall-interactively(realgud:pdb)
```